### PR TITLE
float to double, replacing some func with existing ones in tf_conversions header file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,8 @@ find_package(catkin REQUIRED COMPONENTS
   std_msgs
   geometry_msgs
   genmsg
+  tf
+  tf_conversions
   pcl_conversions
   pcl_ros
 )
@@ -32,6 +34,8 @@ include_directories(
   src
 )
 
+catkin_package() #for using with catkin build
+
 add_executable(01_vec_and_quat examples/01_vector_and_quaternion.cpp src/pose_conversion.cpp include/utils.hpp)
 add_dependencies(01_vec_and_quat ${catkin_EXPORTED_TARGETS})
 target_link_libraries(01_vec_and_quat ${catkin_LIBRARIES})
@@ -48,5 +52,6 @@ add_executable(04_roll_pitch_yaw examples/04_roll_pitch_yaw.cpp src/pose_convers
 add_dependencies(04_roll_pitch_yaw ${catkin_EXPORTED_TARGETS})
 target_link_libraries(04_roll_pitch_yaw ${catkin_LIBRARIES} ${OpenCV_LIBRARIES})
 
-
-
+add_executable(05_pose_conversion examples/05_pose_conversion.cpp src/pose_conversion.cpp include/utils.hpp)
+add_dependencies(05_pose_conversion ${catkin_EXPORTED_TARGETS})
+target_link_libraries(05_pose_conversion ${catkin_LIBRARIES})

--- a/examples/05_pose_conversion.cpp
+++ b/examples/05_pose_conversion.cpp
@@ -5,13 +5,13 @@
 using namespace std;
 using namespace Eigen;
 
-void getTf4x4(const nav_msgs::Odometry o, Eigen::Matrix4f &tf4x4) {
+void getTf4x4(const nav_msgs::Odometry o, Eigen::Matrix4d &tf4x4) {
     const auto &ori = o.pose.pose.orientation;
     const auto &posit = o.pose.pose.position;
-    Eigen::Quaternionf q(ori.w, ori.x, ori.y, ori.z);
-    Eigen::Vector3f t(posit.x, posit.y, posit.z);
+    Eigen::Quaterniond q(ori.w, ori.x, ori.y, ori.z);
+    Eigen::Vector3d t(posit.x, posit.y, posit.z);
 
-    tf4x4 = Eigen::Matrix4f::Identity();
+    tf4x4 = Eigen::Matrix4d::Identity();
     tf4x4.block<3, 3>(0, 0) = q.toRotationMatrix();
     tf4x4.block<3, 1>(0, 3) = t;
 }
@@ -30,17 +30,17 @@ int main(){
   geoPoseInput.orientation.z = 0.777625;
   geoPoseInput.orientation.w = 0.6225425;
 
-  Matrix4f eigenPoseInput; /** Test case 2. eigenPose -> geoPose / xyzrpy */
+  Matrix4d eigenPoseInput; /** Test case 2. eigenPose -> geoPose / xyzrpy */
   eigenPoseInput << -0.6190476, 0.7824968, -0.0669241, 3.5,
                     -0.7619048, -0.6190476, -0.1904762, 4.2,
                     -0.1904762, -0.0669241,  0.9794080, 1.0,
                              0,          0,          0, 1.0;
-  VectorXf xyzrpyInput(6); /** Test case 3. xyzrpy -> geoPose / eigenPose */
+  VectorXd xyzrpyInput(6); /** Test case 3. xyzrpy -> geoPose / eigenPose */
   xyzrpyInput << -4.2, 2.7, 3, 0.02, -1.2, 0.75;
 
   geometry_msgs::Pose geoPose;
-  Matrix4f eigenPose = Matrix4f::Identity();
-  VectorXf xyzrpy(6);
+  Matrix4d eigenPose = Matrix4d::Identity();
+  VectorXd xyzrpy(6);
 
   /**
    * @brief geometry_msgs/Pose -> Eigen::Matrix4f

--- a/include/pose_conversion.h
+++ b/include/pose_conversion.h
@@ -9,6 +9,7 @@
 #include <Eigen/Geometry>
 #include <ros/ros.h>
 #include <tf/tf.h>
+#include <tf_conversions/tf_eigen.h>
 #include <geometry_msgs/Pose.h>
 #include <sensor_msgs/LaserScan.h>
 #include <std_msgs/String.h>
@@ -20,34 +21,34 @@ namespace pose_conversion
     /**
      * @brief Rotation matrix / Transformation matrix of Eigen -> tf::Matrix3x3
      **/
-    tf::Matrix3x3 eigenRot2RotMat(const Eigen::Matrix3f& eigenRotMat);
-    tf::Matrix3x3 getRotMat(const Eigen::Matrix4f& eigenPose); //
+    tf::Matrix3x3 eigenRot2RotMat(const Eigen::Matrix3d& eigenRotMat);
+    tf::Matrix3x3 getRotMat(const Eigen::Matrix4d& eigenPose); //
 
     /**
      * @brief tf::Matrix3x3 -> Rotation matrix / Transformation matrix of Eigen
      **/
-    Eigen::Matrix3f rotMat2EigenRot(const tf::Matrix3x3& rotMat); //
-    void fillEigenPose(const tf::Matrix3x3& rotMat, Eigen::Matrix4f &eigenPose); //
+    Eigen::Matrix3d rotMat2EigenRot(const tf::Matrix3x3& rotMat); //
+    void fillEigenPose(const tf::Matrix3x3& rotMat, Eigen::Matrix4d &eigenPose); //
 
     /**
      * @brief geometry_msgs/Pose <-> Transformation matrix of Eigen
      **/
-    Eigen::Matrix4f geoPose2eigen(const geometry_msgs::Pose& geoPose);
-    geometry_msgs::Pose eigen2geoPose(const Eigen::Matrix4f& eigenPose);
+    Eigen::Matrix4d geoPose2eigen(const geometry_msgs::Pose& geoPose);
+    geometry_msgs::Pose eigen2geoPose(const Eigen::Matrix4d& eigenPose);
 
     /**
      * @brief xyzrpy <-> Transformation matrix of Eigen
      **/
-    Eigen::VectorXf eigen2xyzrpy(const Eigen::Matrix4f& eigenPose);
-    Eigen::Matrix4f xyzrpy2eigen(const float& x, const float& y, const float& z,
-                                 const float& roll, const float& pitch, const float& yaw);
-    Eigen::Matrix4f xyzrpy2eigen(const Eigen::VectorXf& xyzrpy);
+    Eigen::VectorXd eigen2xyzrpy(const Eigen::Matrix4d& eigenPose);
+    Eigen::Matrix4d xyzrpy2eigen(const double& x, const double& y, const double& z,
+                                 const double& roll, const double& pitch, const double& yaw);
+    Eigen::Matrix4d xyzrpy2eigen(const Eigen::VectorXd& xyzrpy);
 
     /**
      * @brief geometry_msgs/Pose <-> xyzrpy
      **/
-    Eigen::VectorXf geoPose2xyzrpy(const geometry_msgs::Pose& geoPose);
-    geometry_msgs::Pose xyzrpy2geoPose(const Eigen::VectorXf& xyzrpy);
+    Eigen::VectorXd geoPose2xyzrpy(const geometry_msgs::Pose& geoPose);
+    geometry_msgs::Pose xyzrpy2geoPose(const Eigen::VectorXd& xyzrpy);
 
 }
 

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -34,7 +34,7 @@
 
 using namespace std;
 
-string ABS_FILE_PATH = "/home/shapelim/catkin_ws/src/Eigen_for_Robotics/materials/odom_poses.txt";
+string ABS_FILE_PATH = "/home/mason/ws/paper_ws/src/Eigen_for_Robotics/materials/odom_poses.txt";
 
 void loadOdom(const string &filePath, vector<nav_msgs::Odometry> &odomBuf){
     std::cout<< "Start loading odom..." << std::endl;

--- a/package.xml
+++ b/package.xml
@@ -18,6 +18,8 @@
   <build_depend>rospy</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
+  <build_depend>tf</build_depend>
+  <build_depend>tf_conversions</build_depend>
   <build_export_depend>roscpp</build_export_depend>
 
   <build_depend>message_generation</build_depend>
@@ -28,6 +30,8 @@
   <exec_depend>rospy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>tf</exec_depend>
+  <exec_depend>tf_conversions</exec_depend>
   <exec_depend>message_runtime</exec_depend>
 
 


### PR DESCRIPTION
As original author mentioned in the README, changing type from float to double frequently seems bad and I don't understand why. (May for saving some memory? but eventually, casting from/to float/double will occur more memory read/write/works for computer.)

Many Eigen <-> tf functions seems using double type only refer [here](https://github.com/ros/geometry/blob/melodic-devel/tf_conversions/include/tf_conversions/tf_eigen.h). So I just unified all into double.
Plus, replaced few functions with the ones in `tf_conversions/tf_eigen.h`.
I shortly commented on each of edited lines.